### PR TITLE
Initial categories

### DIFF
--- a/server/backend/creddie/consts.py
+++ b/server/backend/creddie/consts.py
@@ -15,6 +15,10 @@ CHARS_FOR_UUID = string.ascii_uppercase + string.digits
 
 # Category Table
 CATEGORY_MAX_NAME_LEN=32
+INITIAL_CATEGORIES=[
+    "Dining", "Groceries", "Shopping", "Home Spending", "Transit", "Entertainment",
+    "Bills", "Fees", "Gifts", "Health", "Work", "Travel", "Income"
+]
 
 #Transaction Table
 TBL_MAX_PARTY_LEN=32

--- a/server/backend/creddie/crud/category_crud.py
+++ b/server/backend/creddie/crud/category_crud.py
@@ -25,7 +25,7 @@ class CategoryCRUD(CRUDBase[TxnCategory, UUIDType, CreateCategory, UpdateCategor
         return result.scalar_one_or_none()
 
     def get_all_names(self, sess: Session) -> set:
-        stmt = select(self.model.name).order_by(self.model.created_date)
+        stmt = select(self.model.name)
         result = sess.execute(stmt)
         return set(result.scalars().all())
         

--- a/server/backend/creddie/crud/category_crud.py
+++ b/server/backend/creddie/crud/category_crud.py
@@ -1,6 +1,9 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
 from ..models import TxnCategory
 from .base import CRUDBase
-from ..schemas.types import UUIDType
+from ..schemas.types import UUIDType, CatNameType
 from ..schemas.category_schema import CreateCategory, UpdateCategory
 
 
@@ -13,5 +16,13 @@ class CategoryCRUD(CRUDBase[TxnCategory, UUIDType, CreateCategory, UpdateCategor
         """Initialize the class."""
         super().__init__(*args, **kwargs)
 
+
+    def get_by_name(self, sess: Session, *, name: CatNameType | str):
+        if isinstance(name, str):
+            name = CatNameType(name)
+        get_stmt = select(self.model).where(getattr(self.model, "name") == name.get())
+        result = sess.execute(get_stmt)
+        return result.scalar_one_or_none()
+        
 
 categories = CategoryCRUD(TxnCategory)

--- a/server/backend/creddie/crud/category_crud.py
+++ b/server/backend/creddie/crud/category_crud.py
@@ -17,12 +17,17 @@ class CategoryCRUD(CRUDBase[TxnCategory, UUIDType, CreateCategory, UpdateCategor
         super().__init__(*args, **kwargs)
 
 
-    def get_by_name(self, sess: Session, *, name: CatNameType | str):
+    def get_by_name(self, sess: Session, *, name: CatNameType | str) -> TxnCategory:
         if isinstance(name, str):
             name = CatNameType(name)
         get_stmt = select(self.model).where(getattr(self.model, "name") == name.get())
         result = sess.execute(get_stmt)
         return result.scalar_one_or_none()
+
+    def get_all_names(self, sess: Session) -> set:
+        stmt = select(self.model.name).order_by(self.model.created_date)
+        result = sess.execute(stmt)
+        return set(result.scalars().all())
         
 
 categories = CategoryCRUD(TxnCategory)

--- a/server/backend/creddie/db/initial_data.py
+++ b/server/backend/creddie/db/initial_data.py
@@ -1,0 +1,50 @@
+"""Fill database with initial data, if it isn't already present.
+
+Initial Data:
+1. Input the pre-specified list of categories.
+"""
+import asyncio
+import logging
+
+from sqlalchemy.orm import Session
+
+from creddie.db.session import SessionLocal
+from creddie.schemas.types import CatNameType
+from creddie.schemas.category_schema import CreateCategory
+from creddie.crud import categories
+from creddie.consts import INITIAL_CATEGORIES
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+async def init_categories(sess: Session):
+    """Load initial categories into the table."""
+
+    cats_in_db = categories.get_all_names(sess)
+    if not cats_in_db:
+        logger.info("No Categories found at startup. Loading defaults...")
+        for cat in INITIAL_CATEGORIES:
+            create = CreateCategory(name = cat)
+            categories.create(sess, obj_in=create)
+        cats_in_db = categories.get_all_names(sess)
+        assert cats_in_db == set(INITIAL_CATEGORIES)
+    else:
+        logger.info("Categories found at startup.")
+
+
+async def init() -> None:
+    """Wrap loading initial db."""
+    with SessionLocal() as sess:
+        await init_categories(sess)
+
+
+async def main() -> None:
+    """Begin loading initial data."""
+    logger.info("Creating initial data")
+    await init()
+    logger.info("Initial data created")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/server/backend/prestart.sh
+++ b/server/backend/prestart.sh
@@ -8,4 +8,4 @@ python creddie/db/db_prestart.py
 alembic upgrade head
 
 # add default data if not in the table
-# TODO
+python creddie/db/initial_data.py

--- a/server/backend/tests/crud/test_category_crud.py
+++ b/server/backend/tests/crud/test_category_crud.py
@@ -69,4 +69,3 @@ def test_get_all_names(sess: Session):
         names.append(rdm_cat.name)
     db_names = categories.get_all_names(sess)
     assert set(names) == db_names
-

--- a/server/backend/tests/crud/test_category_crud.py
+++ b/server/backend/tests/crud/test_category_crud.py
@@ -1,3 +1,4 @@
+from sqlalchemy import delete
 from sqlalchemy.orm import Session
 
 from creddie.schemas.category_schema import CreateCategory, UpdateCategory
@@ -58,3 +59,14 @@ def test_get_by_name(sess: Session):
     assert obj.id == rdm_cat.id
     obj2 = categories.get_by_name(sess, name=rdm_name)
     assert obj2.id == rdm_cat.id
+
+def test_get_all_names(sess: Session):
+    # Remove all categories from previous tests
+    sess.execute(delete(TxnCategory))
+    names = []
+    for _ in range(5):
+        rdm_cat = create_random_category(sess)
+        names.append(rdm_cat.name)
+    db_names = categories.get_all_names(sess)
+    assert set(names) == db_names
+

--- a/server/backend/tests/crud/test_category_crud.py
+++ b/server/backend/tests/crud/test_category_crud.py
@@ -1,6 +1,7 @@
 from sqlalchemy.orm import Session
 
 from creddie.schemas.category_schema import CreateCategory, UpdateCategory
+from creddie.schemas.types import CatNameType
 from creddie.models.category_model import TxnCategory
 from creddie.crud import categories
 
@@ -48,3 +49,12 @@ def test_delete_category(sess: Session):
 
     assert rows == num_rows_in_tbl(sess, TxnCategory) + 1
     assert deleted_cat == rdm_cat
+
+def test_get_by_name(sess: Session):
+    rdm_cat = create_random_category(sess)
+    rdm_name = rdm_cat.name
+
+    obj = categories.get_by_name(sess, name=CatNameType(rdm_name))
+    assert obj.id == rdm_cat.id
+    obj2 = categories.get_by_name(sess, name=rdm_name)
+    assert obj2.id == rdm_cat.id


### PR DESCRIPTION
closes #10 

Load initial categories if the table has no entries. Don't if there is at least 1 category in the category table.